### PR TITLE
manaba+RのSP版の終了に伴い未提出課題一覧取得ソースを変更

### DIFF
--- a/src/taskInfo.ts
+++ b/src/taskInfo.ts
@@ -23,6 +23,7 @@ const fetchTaskInfo = async (type: TaskType): Promise<TaskInfo[]> => {
   const domparser = new DOMParser();
   const doc = domparser.parseFromString(htmlText, "text/html");
 
+  validateSource(doc);
   const taskTrs = Array.from(
     doc.querySelectorAll(".stdlist > tbody > tr")
   ).filter((e) => !e.classList.contains("title"));
@@ -40,6 +41,33 @@ const fetchTaskInfo = async (type: TaskType): Promise<TaskInfo[]> => {
       due: tr.children[2].innerHTML.replace(/\s+/g, " "),
     };
   });
+};
+
+const validateSource = (doc: Document) => {
+  // タスクのテーブルの要素について検証
+  const trs = doc.querySelectorAll(".stdlist > tbody > tr");
+
+  // 要素が存在することを確認
+  if (trs.length === 0) {
+    throw new Error("Invalid source: task table header not found");
+  }
+
+  // テーブルのヘッダーの内容が正しいことを確認
+  const header = trs[0].children;
+  if (header[0] && header[0]?.innerHTML.replace(/\s+/g, " ") !== "タイトル") {
+    throw new Error("Invalid source: task table does not have タイトル column");
+  }
+  if (header[1] && header[1].innerHTML.replace(/\s+/g, " ") !== "コース名") {
+    throw new Error("Invalid source: task table does not have コース名 column");
+  }
+  if (
+    header[2] &&
+    header[2].innerHTML.replace(/\s+/g, " ") !== "受付終了日時"
+  ) {
+    throw new Error(
+      "Invalid source: task table does not have 受付終了日時 column"
+    );
+  }
 };
 
 export const fetchTasksInfo = async (): Promise<TasksInfo> => {

--- a/src/taskInfo.ts
+++ b/src/taskInfo.ts
@@ -1,7 +1,7 @@
 const taskListURLs = {
-  query: "https://ct.ritsumei.ac.jp/s/home_summary_query",
-  survey: "https://ct.ritsumei.ac.jp/s/home_summary_survey",
-  report: "https://ct.ritsumei.ac.jp/s/home_summary_report",
+  query: "https://ct.ritsumei.ac.jp/ct/home_summary_query",
+  survey: "https://ct.ritsumei.ac.jp/ct/home_summary_survey",
+  report: "https://ct.ritsumei.ac.jp/ct/home_summary_report",
 } as const;
 
 export type TaskInfo = {
@@ -23,22 +23,21 @@ const fetchTaskInfo = async (type: TaskType): Promise<TaskInfo[]> => {
   const domparser = new DOMParser();
   const doc = domparser.parseFromString(htmlText, "text/html");
 
-  return Array.from(
-    doc.querySelectorAll(".querylist > li > a, .reportlist > li > a")
-  ).map((a) => {
+  const taskTrs = Array.from(
+    doc.querySelectorAll(".stdlist > tbody > tr")
+  ).filter((e) => !e.classList.contains("title"));
+
+  return taskTrs.map((tr) => {
+    const a = tr.querySelector("a");
     const taskPath = a.getAttribute("href");
     const coursePath = taskPath?.replace(/_[a-z]+_[0-9]+/, "");
 
     return {
       url: taskPath && `https://ct.ritsumei.ac.jp/ct/${taskPath}`,
       courseUrl: coursePath && `https://ct.ritsumei.ac.jp/ct/${coursePath}`,
-      title: a.querySelector("h3")?.innerText.replace(/\s+/g, " "),
-      course: a
-        .querySelector<HTMLParagraphElement>(".info1")
-        ?.innerText.replace(/\s+/g, " "),
-      due: a
-        .querySelector<HTMLParagraphElement>(".info2")
-        ?.innerText.replace("受付終了日時：", ""),
+      title: tr.querySelector("h3")?.innerText.replace(/\s+/g, " "),
+      course: tr.children[1].innerHTML.replace(/\s+/g, " "),
+      due: tr.children[2].innerHTML.replace(/\s+/g, " "),
     };
   });
 };

--- a/src/taskList/TaskList.tsx
+++ b/src/taskList/TaskList.tsx
@@ -96,6 +96,7 @@ export const TaskList: FunctionComponent = () => {
   const [openedTab, setOpenedTab] = useState<TabKey>("all");
   const [tasks, setTasks] = useState<TasksInfo | undefined>(undefined);
   const [showAll, setShowAll] = useState<boolean>(false);
+  const [isFailedLoading, setIsFailedLoading] = useState<boolean>(false);
 
   const toggleShowAll = useCallback(async () => {
     const newShowAll = !showAll;
@@ -124,9 +125,14 @@ export const TaskList: FunctionComponent = () => {
   }, []);
 
   useEffect(() => {
-    fetchTasksInfo().then((tasksInfo) => {
-      setTasks(tasksInfo);
-    });
+    fetchTasksInfo()
+      .then((tasksInfo) => {
+        setTasks(tasksInfo);
+      })
+      .catch((e) => {
+        console.error("Failed to fetch tasks \n", e);
+        setIsFailedLoading(true);
+      });
   }, []);
 
   const showingTasks = tasks && getTasks(tasks, openedTab);
@@ -149,82 +155,102 @@ export const TaskList: FunctionComponent = () => {
       </ul>
       <div className="my-infolist-body">
         <div className="groupthreadlist" style={{ minHeight: 156 }}>
-          {showingTasks == null && (
-            <p>
-              読み込み中です <span aria-hidden>&gt; 🐤</span>
-            </p>
-          )}
-          {showingTasks != null && showingTasks.length === 0 && (
+          {!isFailedLoading ? (
+            <>
+              {showingTasks == null && (
+                <p>
+                  読み込み中です <span aria-hidden>&gt; 🐤</span>
+                </p>
+              )}
+              {showingTasks != null && showingTasks.length === 0 && (
+                <>
+                  <p>
+                    未提出の課題はありません！
+                    <span aria-hidden>&gt; 🐤</span>
+                  </p>
+                  <p>
+                    良い一日を！
+                    <span aria-hidden>&gt; 🐑</span>
+                  </p>
+                </>
+              )}
+              {showingTasks != null && (
+                <table>
+                  <tbody>
+                    {showingTasks
+                      .slice(0, showAll ? undefined : 5)
+                      .map((task) => (
+                        <tr
+                          key={task.url}
+                          style={
+                            task.due != null ? getRowStyle(task.due) : undefined
+                          }
+                        >
+                          <td
+                            width="15%"
+                            style={
+                              task.due != null &&
+                              dayjs(task.due).diff(dayjs(), "day") < 7
+                                ? { fontWeight: "bold" }
+                                : undefined
+                            }
+                            title={task.due ?? undefined}
+                          >
+                            {task.due && dayjs(task.due).fromNow()}
+                          </td>
+                          <th style={{ backgroundImage: "none", padding: 0 }}>
+                            <div
+                              className="news-title newsentry"
+                              style={{ width: 350 }}
+                            >
+                              <img
+                                src="/icon-coursedeadline-on.png"
+                                className="inline"
+                                alt="未提出の課題"
+                              />
+                              <a
+                                href={task.url ?? ""}
+                                title={task.title ?? ""}
+                                style={{ width: "auto", display: "inline" }}
+                              >
+                                {task.title}
+                              </a>
+                            </div>
+                          </th>
+                          <td>
+                            <div
+                              className="news-courseinfo"
+                              title={task.course ?? undefined}
+                              style={{
+                                width: 200,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {task.course && (
+                                <a href={task.courseUrl ?? ""}>{task.course}</a>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              )}
+            </>
+          ) : (
             <>
               <p>
-                未提出の課題はありません！
-                <span aria-hidden>&gt; 🐤</span>
+                課題の読み込みに失敗しました <span aria-hidden>🌀</span>
               </p>
               <p>
-                良い一日を！
-                <span aria-hidden>&gt; 🐑</span>
+                <a href="https://github.com/xryuseix/manaba_R_incremented">
+                  manaba+R incremented
+                </a>
+                の開発者にお問い合わせください
               </p>
             </>
-          )}
-          {showingTasks != null && (
-            <table>
-              <tbody>
-                {showingTasks.slice(0, showAll ? undefined : 5).map((task) => (
-                  <tr
-                    key={task.url}
-                    style={task.due != null ? getRowStyle(task.due) : undefined}
-                  >
-                    <td
-                      width="15%"
-                      style={
-                        task.due != null &&
-                        dayjs(task.due).diff(dayjs(), "day") < 7
-                          ? { fontWeight: "bold" }
-                          : undefined
-                      }
-                      title={task.due ?? undefined}
-                    >
-                      {task.due && dayjs(task.due).fromNow()}
-                    </td>
-                    <th style={{ backgroundImage: "none", padding: 0 }}>
-                      <div
-                        className="news-title newsentry"
-                        style={{ width: 350 }}
-                      >
-                        <img
-                          src="/icon-coursedeadline-on.png"
-                          className="inline"
-                          alt="未提出の課題"
-                        />
-                        <a
-                          href={task.url ?? ""}
-                          title={task.title ?? ""}
-                          style={{ width: "auto", display: "inline" }}
-                        >
-                          {task.title}
-                        </a>
-                      </div>
-                    </th>
-                    <td>
-                      <div
-                        className="news-courseinfo"
-                        title={task.course ?? undefined}
-                        style={{
-                          width: 200,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {task.course && (
-                          <a href={task.courseUrl ?? ""}>{task.course}</a>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
           )}
         </div>
         <div className="showmore">


### PR DESCRIPTION
### 影響がある機能
- 課題一覧（`src/taskList/TaskList.tsx`）

### 変更点
- 課題一覧をPC版未提出課題一覧から取得できるように
- 未提出課題一覧の取得ソースとして適切でなければエラーメッセージが表示されるように

### 背景
manaba+Rのスマートフォン用の課題閲覧ページ `https://ct.ritsumei.ac.jp/s/***` が2024年3月に終了しました。

manaba_R_incrementedは `https://ct.ritsumei.ac.jp/s/home_summary_query` などのスマートフォン用の未提出課題一覧ページをソースとして取得を行っていたため、正しく未提出課題一覧を取得することができず「未提出の課題はない」という表示になってしまっていました。

manaba+RのPC用ビューにも未提出課題一覧ビューが追加された（`https://ct.ritsumei.ac.jp/ct/home_summary_report`など）ため、そちらからフェッチができるように変更しました。

また、正しい構造でスクレイピングができなかった際に「未提出課題がない」旨が表示されるのはユーザーの体験として問題があると考えたため、テーブルの見出し行の内容について検証を行い、正しく取得できてなさそうな時にエラーメッセージが表示される機能を追加しました。

### 確認事項
<img width="500" alt="image" src="https://github.com/xryuseix/manaba_R_incremented/assets/12378384/c9339806-abf2-472e-b707-0b705255e93c">

- 全てのタブにそれぞれのタイプの課題が表示される。
- 課題、コースへリンクが動作する

<img width="500" alt="image" src="https://github.com/xryuseix/manaba_R_incremented/assets/12378384/9e4174cf-00df-4caa-90d8-6910162d6b01"> 

*PC版未提出課題一覧のURLが無効だった場合の失敗画面*

- フェッチ自体の失敗があった場合にエラーが表示される
- HTML構造の取得の失敗があった場合にエラーが表示される
- テーブル見出し行の不一致があった場合にエラーが表示される

